### PR TITLE
Add options menu with sound and vibration toggles

### DIFF
--- a/android/Notify/app/src/main/java/com/kevinbedi/notify/MainActivity.java
+++ b/android/Notify/app/src/main/java/com/kevinbedi/notify/MainActivity.java
@@ -3,10 +3,15 @@ package com.kevinbedi.notify;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.Toolbar;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
 import android.view.View;
 import android.view.WindowManager;
 import android.widget.ProgressBar;
 import android.widget.TextView;
+import android.content.SharedPreferences;
 
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.FirebaseUser;
@@ -28,6 +33,11 @@ public class MainActivity extends AppCompatActivity implements GcmTokenManager.L
     private FirebaseAuth mAuth = FirebaseAuth.getInstance();
     private ProgressBar mProgressBar;
     private View mContainer;
+    private Toolbar mToolbar;
+    private boolean mSound;
+    private boolean mVibration;
+    private SharedPreferences mPrefs;
+    private SharedPreferences.Editor mPrEdit;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -41,6 +51,15 @@ public class MainActivity extends AppCompatActivity implements GcmTokenManager.L
 
         mProgressBar = findViewById(R.id.progress_bar);
         mContainer = findViewById(R.id.container);
+        mToolbar = findViewById(R.id.toolbar);
+
+        setSupportActionBar(mToolbar);
+        getSupportActionBar().setDisplayShowTitleEnabled(false);
+
+        mPrefs = getSharedPreferences(getString(R.string.settings_file), MODE_PRIVATE);
+        mPrEdit = mPrefs.edit();
+        mSound = mPrefs.getBoolean(getString(R.string.menu_sound), true);
+        mVibration = mPrefs.getBoolean(getString(R.string.menu_vibration), true);
 
         mAuth.addAuthStateListener(mAuthListener);
 
@@ -75,5 +94,32 @@ public class MainActivity extends AppCompatActivity implements GcmTokenManager.L
     @Override
     public void onTokenGenerated() {
         updateText();
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu){
+        MenuInflater inflater = getMenuInflater();
+        inflater.inflate(R.menu.menu_main, menu);
+        menu.findItem(R.id.sound).setChecked(mSound);
+        menu.findItem(R.id.vibration).setChecked(mVibration);
+        return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item){
+        switch(item.getItemId()){
+            case R.id.sound:
+                mSound = !item.isChecked();
+                item.setChecked(mSound);
+                mPrEdit.putBoolean(getString(R.string.menu_sound), mSound).apply();
+                return true;
+            case R.id.vibration:
+                mVibration = !item.isChecked();
+                item.setChecked(mVibration);
+                mPrEdit.putBoolean(getString(R.string.menu_vibration), mVibration).apply();
+                return true;
+            default:
+                return super.onOptionsItemSelected(item);
+        }
     }
 }

--- a/android/Notify/app/src/main/java/com/kevinbedi/notify/NotifyFirebaseMessagingService.java
+++ b/android/Notify/app/src/main/java/com/kevinbedi/notify/NotifyFirebaseMessagingService.java
@@ -3,8 +3,9 @@ package com.kevinbedi.notify;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.graphics.Color;
-import android.media.RingtoneManager;
+import android.provider.Settings;
 import android.os.Build;
 import android.support.v4.app.NotificationCompat;
 
@@ -20,8 +21,12 @@ public class NotifyFirebaseMessagingService extends FirebaseMessagingService {
     @Override
     public void onMessageReceived(RemoteMessage remoteMessage) {
         NotificationManager manager = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
+        SharedPreferences prefs = getSharedPreferences(getString(R.string.settings_file), MODE_PRIVATE);
+        Boolean sound = prefs.getBoolean(getString(R.string.menu_sound), true);
+        Boolean vibration = prefs.getBoolean(getString(R.string.menu_vibration), true);
         String title = null;
         String text = null;
+
         if (remoteMessage.getNotification() != null) {
             title = remoteMessage.getNotification().getTitle();
             text = remoteMessage.getNotification().getBody();
@@ -41,8 +46,9 @@ public class NotifyFirebaseMessagingService extends FirebaseMessagingService {
                         .setContentTitle(title)
                         .setContentText(text)
                         .setStyle(new NotificationCompat.BigTextStyle().bigText(text))
-                        .setVibrate(new long[] { 150, 300, 150, 600})
-                        .setSound(RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION))
+                        .setVibrate(vibration ? new long[]{150, 300, 150, 600} : new long[]{0L})
+                        .setSound(sound ? Settings.System.DEFAULT_NOTIFICATION_URI : null)
+                        .setLights(Color.BLUE, 1000, 500)
                         .setPriority(PRIORITY_MAX)
                         .setAutoCancel(true)
                         .build());

--- a/android/Notify/app/src/main/res/layout/activity_main.xml
+++ b/android/Notify/app/src/main/res/layout/activity_main.xml
@@ -1,8 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@drawable/background_main">
+    android:background="@drawable/background_main"
+    tools:context=".MainActivity">
+
+    <android.support.v7.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:elevation="4dp"
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"/>
 
     <ProgressBar
         android:id="@+id/progress_bar"
@@ -36,7 +45,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:fontFamily="sans-serif-light"
-                android:text="notify"
+                android:text="@string/app_name_lower"
                 android:textColor="@android:color/white"
                 android:textSize="48sp" />
 
@@ -67,7 +76,7 @@
                 android:layout_marginRight="30dp"
                 android:fontFamily="sans-serif-medium"
                 android:padding="10dp"
-                android:text="YOUR TOKEN"
+                android:text="@string/your_token"
                 android:textColor="@android:color/white"
                 android:textSize="20sp" />
 

--- a/android/Notify/app/src/main/res/menu/menu_main.xml
+++ b/android/Notify/app/src/main/res/menu/menu_main.xml
@@ -1,6 +1,16 @@
-<menu xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools" tools:context=".MainActivity">
-    <item android:id="@+id/action_settings" android:title="@string/action_settings"
-        android:orderInCategory="100" app:showAsAction="never" />
+<menu
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/sound"
+        android:checkable="true"
+        android:orderInCategory="4"
+        android:title="@string/menu_sound"
+        app:showAsAction="never" />
+    <item
+        android:id="@+id/vibration"
+        android:checkable="true"
+        android:orderInCategory="5"
+        android:title="@string/menu_vibration"
+        app:showAsAction="never" />
 </menu>

--- a/android/Notify/app/src/main/res/values/colors.xml
+++ b/android/Notify/app/src/main/res/values/colors.xml
@@ -2,5 +2,5 @@
 <resources>
     <color name="colorPrimary">#FF9800</color>
     <color name="colorPrimaryDark">#F57C00</color>
-    <color name="colorAccent">#FFEB3B</color>
+    <color name="colorAccent">#FFFFFF</color>
 </resources>

--- a/android/Notify/app/src/main/res/values/strings.xml
+++ b/android/Notify/app/src/main/res/values/strings.xml
@@ -1,4 +1,8 @@
 <resources>
     <string name="app_name">Notify</string>
-    <string name="action_settings">Settings</string>
+    <string name="app_name_lower">notify</string>
+    <string name="menu_sound">Sound</string>
+    <string name="menu_vibration">Vibration</string>
+    <string name="settings_file">Settings</string>
+    <string name="your_token">YOUR TOKEN</string>
 </resources>


### PR DESCRIPTION
Hey, me again.
I needed a way to enable or disable sound/vibration from the app.
This creates an options menu with both toggles. (there was already an unused (?) menu_main.xml layout so I just changed that one)
The settings get saved to android shared preferences so they should stick across restarts.
Also moved some hardcoded strings to the strings.xml file for consistency.
Not sure if you'll want to merge this in or not, but here it is anyway in case its useful. (tested on my android 7.1.2 device only)