### PR TITLE
Added curl option -g to notify.sh

### DIFF
--- a/sh/notify.sh
+++ b/sh/notify.sh
@@ -26,7 +26,7 @@ then
   echo "${KEY}" > ~/.notifyreg
 else
   KEY=`cat ~/.notifyreg`
-  curl \
+  curl -g\
   "https://us-central1-notify-b7652.cloudfunctions.net/sendNotification?to=${KEY}&text=${TEXT}" \
   > /dev/null
 


### PR DESCRIPTION
Passing a text with special characters {}[] to notify.sh was not possible. Using the option -g makes it possible.
See https://stackoverflow.com/questions/8333920/passing-a-url-with-brackets-to-curl