### PR TITLE
Play Store link's warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![notify](http://i.imgur.com/OYoRBS3.png)
 
-[Play Store Link](https://play.google.com/store/apps/details?id=com.kevinbedi.notify)
+[~~Play Store Link~~](https://play.google.com/store/apps/details?id=com.kevinbedi.notify) (currently unavailable)
 
 # Installation
 The notify CLI is written with node, so you can install it with npm:


### PR DESCRIPTION
Due to you or Google removed the app from the store, that will be good for users to know that currently, it's not available.